### PR TITLE
Move src/combine_bytes.asm to .text section

### DIFF
--- a/src/combine_bytes.asm
+++ b/src/combine_bytes.asm
@@ -1,3 +1,5 @@
+section .text
+
 combineBytes:
 ;; A function that takes a series of bytes and joins them together as
 ;; a big-endian integer.

--- a/src/systemf.asm
+++ b/src/systemf.asm
@@ -40,9 +40,8 @@ arg_five_mode:  resb 1
 arg_five_len:   resb 1
 
 
-section .includes
-  %include "src/combine_bytes.asm"
-  %include "src/build_jump_table.asm"
+%include "src/combine_bytes.asm"
+%include "src/build_jump_table.asm"
 
 section  .text
 


### PR DESCRIPTION
`src/combine_bytes.asm` is included in `src/systemf.asm` in the `.includes` section, which is not executable. This pull request moves it into the executable `.text` section.

Fixes #6.