### PR TITLE
Add automated builds and release binaries for Ubuntu, Debian, and Arch/Manjaro

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
           tar -czvf systemf-${{ github.ref_name }}-ubuntu.tar.gz -C dist bin
 
       - name: Upload Release Asset (Ubuntu)
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: systemf-${{ github.ref_name }}-ubuntu.tar.gz
         env:
@@ -55,7 +55,7 @@ jobs:
           tar -czvf systemf-${{ github.ref_name }}-debian.tar.gz -C dist bin
 
       - name: Upload Release Asset (Debian)
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: systemf-${{ github.ref_name }}-debian.tar.gz
         env:
@@ -83,7 +83,7 @@ jobs:
           tar -czvf systemf-${{ github.ref_name }}-arch.tar.gz -C dist bin
 
       - name: Upload Release Asset (Arch/Manjaro)
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: systemf-${{ github.ref_name }}-arch.tar.gz
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,90 @@
+name: Build and Release Binaries
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+
+jobs:
+  build-ubuntu:
+    name: Build on Ubuntu
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: sudo apt-get update && sudo apt-get install -y make nasm
+
+      - name: Build project
+        run: make clean build
+
+      - name: Archive binaries
+        run: |
+          mkdir -p dist
+          cp -r bin dist/
+          tar -czvf systemf-${{ github.ref_name }}-ubuntu.tar.gz -C dist bin
+
+      - name: Upload Release Asset (Ubuntu)
+        uses: softprops/action-gh-release@v2
+        with:
+          files: systemf-${{ github.ref_name }}-ubuntu.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-debian:
+    name: Build on Debian (Docker)
+    runs-on: ubuntu-latest
+    container:
+      image: debian:stable-slim
+    steps:
+      - name: Install git, make, nasm
+        run: apt-get update && apt-get install -y git make nasm
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build project
+        run: make clean build
+
+      - name: Archive binaries
+        run: |
+          mkdir -p dist
+          cp -r bin dist/
+          tar -czvf systemf-${{ github.ref_name }}-debian.tar.gz -C dist bin
+
+      - name: Upload Release Asset (Debian)
+        uses: softprops/action-gh-release@v2
+        with:
+          files: systemf-${{ github.ref_name }}-debian.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-arch:
+    name: Build on Arch/Manjaro (Docker)
+    runs-on: ubuntu-latest
+    container:
+      image: archlinux:base
+    steps:
+      - name: Install git, make, nasm
+        run: pacman -Sy --noconfirm git make nasm
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build project
+        run: make clean build
+
+      - name: Archive binaries
+        run: |
+          mkdir -p dist
+          cp -r bin dist/
+          tar -czvf systemf-${{ github.ref_name }}-arch.tar.gz -C dist bin
+
+      - name: Upload Release Asset (Arch/Manjaro)
+        uses: softprops/action-gh-release@v2
+        with:
+          files: systemf-${{ github.ref_name }}-arch.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
       image: debian:stable-slim
     steps:
       - name: Install git, make and nasm
-        run: apt-get update && apt-get install -y git make nasm
+        run: apt-get update && apt-get install -y git make nasm build-essential
 
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install build dependencies
         run: sudo apt-get update && sudo apt-get install -y make nasm
@@ -44,7 +44,7 @@ jobs:
         run: apt-get update && apt-get install -y git make nasm build-essential
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build project
         run: make clean build
@@ -73,7 +73,7 @@ jobs:
         run: pacman -Sy --noconfirm git make nasm
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build project
         run: make clean build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
         with:
           path: artifacts
       - name: Upload Release Assets
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@v3.1
         with:
           files: |
             artifacts/systemf-arch/systemf-arch.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           files: systemf-${{ github.ref_name }}.tar.gz
-          tag_name: "ubuntu-release"
+          tag_name: "ubuntu-release-v${{ github.ref_name }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -59,7 +59,7 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           files: systemf-${{ github.ref_name }}.tar.gz
-          tag_name: "debian-release"
+          tag_name: "debian-release-v${{ github.ref_name }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -88,6 +88,6 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           files: systemf-${{ github.ref_name }}.tar.gz
-          tag_name: "arch-release"
+          tag_name: "arch-release-v${{ github.ref_name }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
     tags:
       - 'v*.*.*'
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -107,7 +112,7 @@ jobs:
             artifacts/systemf-arch/systemf-arch.tar.gz
             artifacts/systemf-debian/systemf-debian.tar.gz
             artifacts/systemf-ubuntu/systemf-ubuntu.tar.gz
-          tag_name: "${{ github.ref_name }}"
+          tag_name: "${{ inputs.tag || github.ref_name }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
     container:
       image: debian:stable-slim
     steps:
-      - name: Install git, make, nasm
+      - name: Install git, make and nasm
         run: apt-get update && apt-get install -y git make nasm
 
       - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,12 +24,13 @@ jobs:
         run: |
           mkdir -p dist
           cp -r bin dist/
-          tar -czvf systemf-${{ github.ref_name }}-ubuntu.tar.gz -C dist bin
+          tar -czvf systemf-${{ github.ref_name }}.tar.gz -C dist bin
 
       - name: Upload Release Asset (Ubuntu)
         uses: softprops/action-gh-release@v3
         with:
-          files: systemf-${{ github.ref_name }}-ubuntu.tar.gz
+          files: systemf-${{ github.ref_name }}.tar.gz
+          tag_name: "ubuntu-release"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -52,12 +53,13 @@ jobs:
         run: |
           mkdir -p dist
           cp -r bin dist/
-          tar -czvf systemf-${{ github.ref_name }}-debian.tar.gz -C dist bin
+          tar -czvf systemf-${{ github.ref_name }}.tar.gz -C dist bin
 
       - name: Upload Release Asset (Debian)
         uses: softprops/action-gh-release@v3
         with:
-          files: systemf-${{ github.ref_name }}-debian.tar.gz
+          files: systemf-${{ github.ref_name }}.tar.gz
+          tag_name: "debian-release"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -80,11 +82,12 @@ jobs:
         run: |
           mkdir -p dist
           cp -r bin dist/
-          tar -czvf systemf-${{ github.ref_name }}-arch.tar.gz -C dist bin
+          tar -czvf systemf-${{ github.ref_name }}.tar.gz -C dist bin
 
       - name: Upload Release Asset (Arch/Manjaro)
         uses: softprops/action-gh-release@v3
         with:
-          files: systemf-${{ github.ref_name }}-arch.tar.gz
+          files: systemf-${{ github.ref_name }}.tar.gz
+          tag_name: "arch-release"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7.0.1
 
       - name: Install build dependencies
         run: sudo apt-get update && sudo apt-get install -y make nasm
@@ -46,7 +46,7 @@ jobs:
         run: apt-get update && apt-get install -y git make nasm build-essential
 
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7.0.1
 
       - name: Build project
         run: make clean build
@@ -73,7 +73,7 @@ jobs:
         run: pacman -Syu --noconfirm git make nasm
 
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7.0.1
 
       - name: Build project
         run: make clean build
@@ -97,11 +97,11 @@ jobs:
     needs: [build-arch, build-debian, build-ubuntu]
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         with:
           path: artifacts
       - name: Upload Release Assets
-        uses: softprops/action-gh-release@v3.1
+        uses: softprops/action-gh-release@v3.0.2
         with:
           files: |
             artifacts/systemf-arch/systemf-arch.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,15 +24,14 @@ jobs:
         run: |
           mkdir -p dist
           cp -r bin dist/
-          tar -czvf systemf-${{ github.ref_name }}.tar.gz -C dist bin
+          tar -czvf systemf-ubuntu.tar.gz -C dist bin
 
-      - name: Upload Release Asset (Ubuntu)
-        uses: softprops/action-gh-release@v3
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7.0.1
         with:
-          files: systemf-${{ github.ref_name }}.tar.gz
-          tag_name: "ubuntu-release-v${{ github.ref_name }}"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          name: systemf-ubuntu.tar.gz
+          path: systemf-ubuntu.tar.gz
+          if-no-files-found: error
 
   build-debian:
     name: Build on Debian (Docker)
@@ -53,15 +52,13 @@ jobs:
         run: |
           mkdir -p dist
           cp -r bin dist/
-          tar -czvf systemf-${{ github.ref_name }}.tar.gz -C dist bin
-
-      - name: Upload Release Asset (Debian)
-        uses: softprops/action-gh-release@v3
+          tar -czvf systemf-debian.tar.gz -C dist bin
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7.0.1
         with:
-          files: systemf-${{ github.ref_name }}.tar.gz
-          tag_name: "debian-release-v${{ github.ref_name }}"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          name: systemf-debian.tar.gz
+          path: systemf-debian.tar.gz
+          if-no-files-found: error
 
   build-arch:
     name: Build on Arch/Manjaro (Docker)
@@ -82,12 +79,29 @@ jobs:
         run: |
           mkdir -p dist
           cp -r bin dist/
-          tar -czvf systemf-${{ github.ref_name }}.tar.gz -C dist bin
+          tar -czvf systemf-arch.tar.gz -C dist bin
 
-      - name: Upload Release Asset (Arch/Manjaro)
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: systemf-arch.tar.gz
+          path: systemf-arch.tar.gz
+          if-no-files-found: error
+
+  release:
+    name: Upload releases
+    runs-on: ubuntu-latest
+    needs: [build-arch, build-debian, build-ubuntu]
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v3.1.0
+        with:
+          name: systemf-arch.tar.gz systemf-debian.tar.gz systemf-ubuntu.tar.gz
+      - name: Upload Release Assets
         uses: softprops/action-gh-release@v3
         with:
-          files: systemf-${{ github.ref_name }}.tar.gz
-          tag_name: "arch-release-v${{ github.ref_name }}"
+          files: systemf-arch.tar.gz systemf-debian.tar.gz systemf-ubuntu.tar.gz
+          tag_name: "release-v${{ github.ref_name }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
       - 'v*.*.*'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   build-ubuntu:
     name: Build on Ubuntu
@@ -29,7 +32,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: systemf-ubuntu.tar.gz
+          name: systemf-ubuntu
           path: systemf-ubuntu.tar.gz
           if-no-files-found: error
 
@@ -56,7 +59,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: systemf-debian.tar.gz
+          name: systemf-debian
           path: systemf-debian.tar.gz
           if-no-files-found: error
 
@@ -67,7 +70,7 @@ jobs:
       image: archlinux:base
     steps:
       - name: Install git, make, nasm
-        run: pacman -Sy --noconfirm git make nasm
+        run: pacman -Syu --noconfirm git make nasm
 
       - name: Checkout code
         uses: actions/checkout@v6
@@ -84,7 +87,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: systemf-arch.tar.gz
+          name: systemf-arch
           path: systemf-arch.tar.gz
           if-no-files-found: error
 
@@ -94,14 +97,17 @@ jobs:
     needs: [build-arch, build-debian, build-ubuntu]
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v3.1.0
+        uses: actions/download-artifact@v4
         with:
-          name: systemf-arch.tar.gz systemf-debian.tar.gz systemf-ubuntu.tar.gz
+          path: artifacts
       - name: Upload Release Assets
         uses: softprops/action-gh-release@v3
         with:
-          files: systemf-arch.tar.gz systemf-debian.tar.gz systemf-ubuntu.tar.gz
-          tag_name: "release-v${{ github.ref_name }}"
+          files: |
+            artifacts/systemf-arch/systemf-arch.tar.gz
+            artifacts/systemf-debian/systemf-debian.tar.gz
+            artifacts/systemf-ubuntu/systemf-ubuntu.tar.gz
+          tag_name: "${{ github.ref_name }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         


### PR DESCRIPTION
This update introduces a GitHub Actions workflow to automate the building and releasing of binaries for multiple systems, including Ubuntu, Debian, and Arch/Manjaro. Additionally, the installation step description for Debian has been updated to improve clarity.

Fixes [ajyoon/systemf#8](https://github.com/ajyoon/systemf/issues/8)